### PR TITLE
feat: add middleware support

### DIFF
--- a/app/Middlewares/LoggingMiddleware.php
+++ b/app/Middlewares/LoggingMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Middlewares;
+
+use Infra\Http\Request;
+use Infra\Http\Response;
+use Infra\Interfaces\MiddlewareInterface;
+use Infra\Interfaces\RequestHandlerInterface;
+
+class LoggingMiddleware implements MiddlewareInterface
+{
+    public function process(Request $request, RequestHandlerInterface $handler): Response
+    {
+        info('Route: '.$request->getPath().' accessed');
+
+        return $handler->handle($request);
+    }
+}

--- a/app/Routes/web.php
+++ b/app/Routes/web.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use App\Handlers\Web\HomeHandler;
+use App\Middlewares\LoggingMiddleware;
 use Infra\Http\Router;
 
 return function (Router $router) {
-    $router->get('/', HomeHandler::class);
+    $router->get('/', HomeHandler::class)
+        ->addMiddlewares([LoggingMiddleware::class]);
 };

--- a/infra/Http/Handlers/MiddlewareHandler.php
+++ b/infra/Http/Handlers/MiddlewareHandler.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Infra\Http\Handlers;
+
+use Infra\Http\Request;
+use Infra\Http\Response;
+use Infra\Interfaces\MiddlewareInterface;
+use Infra\Interfaces\RequestHandlerInterface;
+
+readonly class MiddlewareHandler implements RequestHandlerInterface
+{
+    public function __construct(
+        private MiddlewareInterface $middleware,
+        private RequestHandlerInterface $handler
+    ) {}
+
+    public function handle(Request $request): Response
+    {
+        return $this->middleware->process($request, $this->handler);
+    }
+}

--- a/infra/Http/MiddlewareDispatcher.php
+++ b/infra/Http/MiddlewareDispatcher.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infra\Http;
+
+use Infra\Http\Handlers\MiddlewareHandler;
+use Infra\Interfaces\MiddlewareInterface;
+use Infra\Interfaces\RequestHandlerInterface;
+
+readonly class MiddlewareDispatcher
+{
+    /** @param  class-string<MiddlewareInterface>[]|MiddlewareInterface[] $middlewares */
+    public function __construct(
+        private RequestHandlerInterface $routeHandler,
+        private array $middlewares
+    ) {}
+
+    public function dispatch(Request $request): Response
+    {
+        $handler = $this->routeHandler;
+
+        foreach (array_reverse($this->middlewares) as $middleware) {
+            if (is_string($middleware)) {
+                $middleware = new $middleware;
+            }
+
+            $handler = new MiddlewareHandler($middleware, $handler);
+        }
+
+        return $handler->handle($request);
+    }
+}

--- a/infra/Http/Route.php
+++ b/infra/Http/Route.php
@@ -5,12 +5,16 @@ declare(strict_types=1);
 namespace Infra\Http;
 
 use Infra\Enums\HttpMethod;
+use Infra\Interfaces\MiddlewareInterface;
 use Infra\Interfaces\RequestHandlerInterface;
 
 class Route
 {
     /** @var array<string,float|int|string> */
     private array $params;
+
+    /** @var class-string<MiddlewareInterface>[]|MiddlewareInterface[] */
+    private array $middlewares = [];
 
     private string $pattern;
 
@@ -78,5 +82,19 @@ class Route
         }
 
         return $value;
+    }
+
+    /** @param class-string<MiddlewareInterface>[]|MiddlewareInterface[] $middlewares */
+    public function addMiddlewares(array $middlewares): void
+    {
+        foreach ($middlewares as $middleware) {
+            $this->middlewares[] = $middleware;
+        }
+    }
+
+    /** @return class-string<MiddlewareInterface>[]| MiddlewareInterface[] */
+    public function getMiddlewares(): array
+    {
+        return $this->middlewares;
     }
 }

--- a/infra/Interfaces/MiddlewareInterface.php
+++ b/infra/Interfaces/MiddlewareInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Infra\Interfaces;
+
+use Infra\Http\Request;
+use Infra\Http\Response;
+
+interface MiddlewareInterface
+{
+    public function process(Request $request, RequestHandlerInterface $handler): Response;
+}


### PR DESCRIPTION
This PR introduces middleware support to the framework, enabling the execution of pre-request logic.

Key changes include:
- A `MiddlewareDispatcher` to process a stack of middlewares.
- A `MiddlewareInterface` to define the contract for middlewares.
- Updates to `Route` and `Router` to handle
  middleware registration and execution.
- An example `LoggingMiddleware` to demonstrate the new functionality.